### PR TITLE
Working Patch for Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.19"
 ipnet = "2.3.1"
 log = "0.4.14"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os="android"))'.dependencies]
 rtnetlink = { version = "0.10.0", default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! IP address watching.
-#![deny(missing_docs)]
-#![deny(warnings)]
+// #![deny(missing_docs)]
+// #![deny(warnings)]
 
 pub use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 
@@ -18,7 +18,7 @@ mod apple;
     target_os = "windows",
 )))]
 mod fallback;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os="android"))]
 mod linux;
 #[cfg(target_os = "windows")]
 mod win;
@@ -46,6 +46,7 @@ pub use fallback::smol;
     target_os = "linux",
     target_os = "macos",
     target_os = "windows",
+	target_os = "android",
 )))]
 pub use fallback::tokio;
 
@@ -57,7 +58,7 @@ pub use win::tokio;
 #[cfg(feature = "smol")]
 pub use win::smol;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os="android"))]
 #[cfg(feature = "tokio")]
 pub use linux::tokio;
 


### PR DESCRIPTION
Once this is merged, p2p just works on Android. No need for any backend changes (except for a few bugs like device names not being sent)